### PR TITLE
Raises error on close if now rows have been added...

### DIFF
--- a/lib/pg_data_encoder/encode_for_copy.rb
+++ b/lib/pg_data_encoder/encode_for_copy.rb
@@ -19,7 +19,7 @@ module PgDataEncoder
 
     def close
       @closed = true
-      @io.write([-1].pack("n"))
+      @io.write([-1].pack("n")) rescue raise Exception.new("No rows have been added to the encoder!")
       @io.rewind
     end
 

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -1,0 +1,8 @@
+require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
+
+describe "throwing errors" do
+  it "should raise an error when no rows have been added to the encoder" do
+    encoder = PgDataEncoder::EncodeForCopy.new
+    expect { encoder.close }.to raise_error
+  end
+end


### PR DESCRIPTION
Before this if you instantiated an encoder and accidently tried to copy
to a table without adding anything to the encoder it would just throw
the error:

```
NoMethodError: undefined method `write` for nil:NilClass from ...../encoder_for_copy.rb:22:in `close`
```

Now if something happened like:

``` ruby
encoder = PgDataEncoder::EncodeForCopy.new(use_tempfile: true)

collection.each do |thing|
  if impossible_thing # this is never true
    encoder.add(thing.id, thing.name, thing.other_thing)
  end
  Thing.pg_copy_from(encoder.get_io, format: :binary, columns: [:id, :name, :other_thing])
```

Instead of throwing a NoMethodError you'll get a more helpful error to
put you on the right track.
