### PR TITLE
Add rake as a development dependency

### DIFF
--- a/pg_data_encoder.gemspec
+++ b/pg_data_encoder.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
+  gem.add_development_dependency("rake")
   gem.add_development_dependency("rspec", ">= 2.12.0")
   gem.add_development_dependency("rspec-core", ">= 2.12.0")
 end


### PR DESCRIPTION
This avoids errors when running `bundle exec rake -T`, which some tools do automatically.
